### PR TITLE
fix/docker-shared-middleware-build-context

### DIFF
--- a/Backend/docker-compose.yml
+++ b/Backend/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   gateway:
     build:
-      context: ./services/gateway
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/gateway/Dockerfile
     ports:
       - "8080:8080"
     environment:
@@ -10,8 +10,8 @@ services:
 
   auth-service:
     build:
-      context: ./services/auth-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/auth-service/Dockerfile
     ports:
       - "3001:3001"
     environment:
@@ -19,8 +19,8 @@ services:
 
   items-service:
     build:
-      context: ./services/items-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/items-service/Dockerfile
     ports:
       - "3002:3002"
     environment:
@@ -28,8 +28,8 @@ services:
 
   requests-service:
     build:
-      context: ./services/requests-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/requests-service/Dockerfile
     ports:
       - "3003:3003"
     environment:
@@ -37,8 +37,8 @@ services:
 
   messaging-service:
     build:
-      context: ./services/messaging-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/messaging-service/Dockerfile
     ports:
       - "3004:3004"
     environment:

--- a/Backend/services/auth-service/Dockerfile
+++ b/Backend/services/auth-service/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY package*.json ./
+COPY services/auth-service/package*.json ./
 RUN npm install --omit=dev
-COPY . .
+COPY services/auth-service/. .
+COPY shared/ /shared
 EXPOSE 3001
 ENV PORT=3001
 CMD ["npm", "start"]

--- a/Backend/services/gateway/Dockerfile
+++ b/Backend/services/gateway/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY package*.json ./
+COPY services/gateway/package*.json ./
 RUN npm install --omit=dev
-COPY . .
+COPY services/gateway/. .
+COPY shared/ /shared
 EXPOSE 8080
 ENV PORT=8080
 CMD ["npm", "start"]

--- a/Backend/services/items-service/Dockerfile
+++ b/Backend/services/items-service/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY package*.json ./
+COPY services/items-service/package*.json ./
 RUN npm install --omit=dev
-COPY . .
+COPY services/items-service/. .
+COPY shared/ /shared
 EXPOSE 3002
 ENV PORT=3002
 CMD ["npm", "start"]

--- a/Backend/services/messaging-service/Dockerfile
+++ b/Backend/services/messaging-service/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY package*.json ./
+COPY services/messaging-service/package*.json ./
 RUN npm install --omit=dev
-COPY . .
+COPY services/messaging-service/. .
+COPY shared/ /shared
 EXPOSE 3004
 ENV PORT=3004
 CMD ["npm", "start"]

--- a/Backend/services/requests-service/Dockerfile
+++ b/Backend/services/requests-service/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY package*.json ./
+COPY services/requests-service/package*.json ./
 RUN npm install --omit=dev
-COPY . .
+COPY services/requests-service/. .
+COPY shared/ /shared
 EXPOSE 3003
 ENV PORT=3003
 CMD ["npm", "start"]


### PR DESCRIPTION
Each service's Dockerfile used its own directory as the build context, so [shared](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) was invisible to Docker and never copied into any image. Any service importing from shared/ would crash at startup with Cannot find module '../../../../shared/index'.

Changes
docker-compose.yml — set context: . (Backend root) for all 5 services so Docker can access the full backend directory tree during every build
All 5 Dockerfiles — updated COPY paths to reference their service subdirectory explicitly, added COPY shared/ /shared to make shared code available inside every container

Closes #87 