### PR TITLE
chore: add messaging service to dev and start scripts

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -8,8 +8,8 @@
     "shared"
   ],
   "scripts": {
-    "dev": "concurrently -n gw,auth,items,req \"npm run dev:gateway\" \"npm run dev:auth\" \"npm run dev:items\" \"npm run dev:requests\"",
-    "start": "concurrently -n gw,auth,items,req \"npm run start:gateway\" \"npm run start:auth\" \"npm run start:items\" \"npm run start:requests\"",
+    "dev": "concurrently -n gw,auth,items,req,msg \"npm run dev:gateway\" \"npm run dev:auth\" \"npm run dev:items\" \"npm run dev:requests\" \"npm run dev:messaging\"",
+    "start": "concurrently -n gw,auth,items,req,msg \"npm run start:gateway\" \"npm run start:auth\" \"npm run start:items\" \"npm run start:requests\" \"npm run start:messaging\"",
     "dev:gateway": "npm run dev -w gateway",
     "dev:auth": "npm run dev -w auth-service",
     "dev:items": "npm run dev -w items-service",
@@ -18,6 +18,7 @@
     "start:gateway": "npm start -w gateway",
     "start:auth": "npm start -w auth-service",
     "start:items": "npm start -w items-service",
+    "start:messaging": "npm start -w messaging-service",
     "start:requests": "npm start -w requests-service"
   },
   "devDependencies": {


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes an issue where the messaging-service was not included in the root-level dev and start scripts.

Although dev:messaging existed in package.json, it was never added to the root concurrently commands. As a result, running npm run dev or npm run start only started 4 out of the 5 backend services.

This update ensures that the messaging service is started alongside the other services.

Fixes # (issue)

-  Added msg label to the concurrently command in:
    -  dev
    -  start
- Added "npm run dev:messaging" to the dev script
- Added "npm run start:messaging" to the start script
- Added missing script:
  - "start:messaging": "npm start -w messaging-service"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Ran npm run dev and verified all 5 services start successfully
- Ran npm run start and verified all 5 services start successfully 
- Confirmed log prefixes include msg for messaging-service

Closes #92 