### PR TITLE
feat: enhance token retrieval to support Bearer token in authorizatio…

### DIFF
--- a/Backend/services/auth-service/src/middleware/auth.js
+++ b/Backend/services/auth-service/src/middleware/auth.js
@@ -3,7 +3,11 @@ const User = require("../models/User");
 
 const auth = async (req, res, next) => {
   try {
-    const token = req.cookies.token;
+    const token =
+      req.cookies?.token ||
+      (req.headers.authorization?.startsWith("Bearer ")
+        ? req.headers.authorization.split(" ")[1]
+        : null);
 
     if (!token) {
       return res

--- a/Backend/services/auth-service/src/routes/authRoutes.js
+++ b/Backend/services/auth-service/src/routes/authRoutes.js
@@ -41,6 +41,7 @@ router.post("/register", async (req, res) => {
 
     res.status(201).json({
       message: "User registered successfully",
+      token,
       user: {
         id: user._id,
         name: user.name,
@@ -90,6 +91,7 @@ router.post("/login", async (req, res) => {
 
     res.json({
       message: "Login successful",
+      token,
       user: {
         id: user._id,
         name: user.name,

--- a/Backend/services/gateway/src/middleware/auth.js
+++ b/Backend/services/gateway/src/middleware/auth.js
@@ -13,7 +13,11 @@ if (!JWT_SECRET) {
  * On failure, responds with 401 immediately.
  */
 const verifyJWT = (req, res, next) => {
-  const token = req.cookies?.token;
+  const token =
+    req.cookies?.token ||
+    (req.headers.authorization?.startsWith("Bearer ")
+      ? req.headers.authorization.split(" ")[1]
+      : null);
 
   if (!token) {
     return res

--- a/Backend/services/items-service/src/middleware/auth.js
+++ b/Backend/services/items-service/src/middleware/auth.js
@@ -15,7 +15,11 @@ const User =
 
 const auth = async (req, res, next) => {
   try {
-    const token = req.cookies.token;
+    const token =
+      req.cookies?.token ||
+      (req.headers.authorization?.startsWith("Bearer ")
+        ? req.headers.authorization.split(" ")[1]
+        : null);
 
     if (!token) {
       return res

--- a/Backend/services/messaging-service/src/middleware/auth.js
+++ b/Backend/services/messaging-service/src/middleware/auth.js
@@ -13,7 +13,11 @@ const User =
 
 const auth = async (req, res, next) => {
   try {
-    const token = req.cookies.token;
+    const token =
+      req.cookies?.token ||
+      (req.headers.authorization?.startsWith("Bearer ")
+        ? req.headers.authorization.split(" ")[1]
+        : null);
 
     if (!token) {
       return res


### PR DESCRIPTION
## Description

This PR implements dual-source token extraction so the backend supports authentication via:

1. **HttpOnly cookie (`token`)** — existing behaviour (unchanged)
2. **`Authorization: Bearer <token>` header** — newly supported

Previously, the frontend already sent a Bearer token in the `Authorization` header (via `axios.js`), but the backend ignored it. This made the `localStorage` token storage effectively unused.  

With this change:

- Cookie authentication continues to work exactly as before.
- If no cookie is present, the backend now falls back to the Bearer token header.
- `POST /auth/login` and `POST /auth/register` now return the `token` in the JSON response body so the frontend can persist it in `localStorage`.

This enables:
- Mobile clients
- API consumers
- Non-browser environments
- Tools like Postman

to authenticate without relying on cookies.

Fixes #97

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## What Changed

### 🔐 Auth Middleware (All Services)

Updated token extraction logic from:

```js
const token = req.cookies.token;
```

to:

```js
const token =
  req.cookies?.token ||
  (req.headers.authorization?.startsWith("Bearer ")
    ? req.headers.authorization.split(" ")[1]
    : null);
```

Applied consistently across:

- `auth-service`
- `gateway`
- `items-service`
- `messaging-service`

Cookie still takes priority for security and backward compatibility.

---

### 🔁 Auth Routes

Updated:

- `POST /auth/register`
- `POST /auth/login`

to include `token` in the JSON response body.

No change to cookie behaviour — the cookie is still set as before.

---

## How Has This Been Tested?

Manual verification using Postman and browser:

1. ✅ Login returns `token` in JSON body.
2. ✅ Requests with only `Authorization: Bearer <token>` (no cookie) succeed.
3. ✅ Requests with only cookie succeed.
4. ✅ When both are present, cookie is used.
5. ✅ Missing token (no cookie + no header) returns `401`.
6. ✅ Existing browser flow (with `withCredentials: true`) works unchanged.

---

## Backwards Compatibility

- No breaking changes.
- Existing cookie-based auth continues to function.
- Frontend `axios.js` required no changes.

---