### PR TITLE
feat: enhance LinkedIn OAuth flow with user cancellation handling and…

### DIFF
--- a/Backend/services/auth-service/src/routes/authRoutes.js
+++ b/Backend/services/auth-service/src/routes/authRoutes.js
@@ -195,7 +195,17 @@ router.patch("/me", auth, async (req, res) => {
 // ===========================================================================
 
 // GET /api/auth/linkedin - Initiate LinkedIn OAuth flow
-router.get("/linkedin", passport.authenticate("linkedin"));
+router.get("/linkedin", (req, res, next) => {
+  // Detect whether the user came from /register or /login using the Referer header
+  const referer = req.get("Referer") || "";
+  const mode = referer.includes("/register") ? "signup" : "login";
+  res.cookie("linkedin_auth_mode", mode, {
+    httpOnly: true,
+    maxAge: 10 * 60 * 1000, // 10 minutes
+    sameSite: "lax",
+  });
+  passport.authenticate("linkedin")(req, res, next);
+});
 
 // ===========================================================================
 
@@ -204,9 +214,25 @@ router.get(
   "/linkedin/callback",
   (req, res, next) => {
     const clientUrl = process.env.CLIENT_URL || "http://localhost:3000";
-    passport.authenticate("linkedin", {
-      session: false,
-      failureRedirect: `${clientUrl}/login?error=linkedin_failed`,
+    const mode = req.cookies?.linkedin_auth_mode || "login";
+    const fallbackPath = mode === "signup" ? "/register" : "/login";
+
+    // Clear the mode cookie
+    res.clearCookie("linkedin_auth_mode");
+
+    passport.authenticate("linkedin", { session: false }, (err, user) => {
+      // Handle user cancellation or any OAuth error
+      if (err || !user) {
+        const errorType = err?.code === "user_cancelled_login" || err?.code === "user_cancelled_authorize"
+          ? "linkedin_cancelled"
+          : "linkedin_failed";
+        logger.warn("LinkedIn OAuth callback error", { error: err?.message, code: err?.code, mode });
+        return res.redirect(`${clientUrl}${fallbackPath}?error=${errorType}`);
+      }
+
+      // Success — issue token and redirect home
+      req.user = user;
+      next();
     })(req, res, next);
   },
   (req, res) => {


### PR DESCRIPTION
Fixes an issue where cancelling the LinkedIn OAuth flow showed a raw error page instead of redirecting back to Login/Register.

### Changes
- Store auth mode (`login` / `signup`) in a short-lived cookie using the `Referer` header in `GET /api/auth/linkedin`.
- Replace `failureRedirect` with Passport custom callback in `GET /api/auth/linkedin/callback`.
- Properly handle `AuthorizationError` on cancel.
- Redirect:
  - `/login?error=linkedin_cancelled`
  - `/register?error=linkedin_cancelled`
  - Fallback: `?error=linkedin_failed`
- No changes to successful auth flow.

Fixes #102 

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

---

## How Has This Been Tested?

- Cancel OAuth from Login → redirected to `/login?error=linkedin_cancelled`
- Cancel OAuth from Register → redirected to `/register?error=linkedin_cancelled`
- Simulated OAuth failure → redirected with `?error=linkedin_failed`
- Successful login flow works as before

---