### PR TITLE
feat: add sizeProfile to user model and update /me endpoints for size…

### DIFF
--- a/Backend/services/auth-service/src/models/User.js
+++ b/Backend/services/auth-service/src/models/User.js
@@ -41,6 +41,12 @@ const userSchema = new mongoose.Schema(
     gender: {
       type: String,
     },
+    sizeProfile: {
+      height: { type: String, default: "" },
+      fitPreference: { type: String, default: "" },
+      topSize: { type: String, default: "" },
+      bottomSize: { type: String, default: "" },
+    },
     activeRole: {
       type: String,
       enum: ["borrower", "lender"],

--- a/Backend/services/auth-service/src/routes/authRoutes.js
+++ b/Backend/services/auth-service/src/routes/authRoutes.js
@@ -139,6 +139,7 @@ router.get("/me", auth, async (req, res) => {
         activeRole: req.user.activeRole,
         profilePhoto: req.user.profilePhoto,
         bio: req.user.bio,
+        sizeProfile: req.user.sizeProfile,
         isProfileComplete: req.user.isProfileComplete,
         isRestricted: req.user.isRestricted,
         badges: req.user.badges,
@@ -163,7 +164,23 @@ router.patch("/me", auth, async (req, res) => {
     if (activeRole && ["borrower", "lender"].includes(activeRole)) {
       updates.activeRole = activeRole;
     }
-    if (sizeProfile !== undefined) updates.sizeProfile = sizeProfile;
+
+    // Validate and apply sizeProfile with dot-notation for partial updates
+    if (sizeProfile !== undefined) {
+      if (typeof sizeProfile !== "object" || sizeProfile === null || Array.isArray(sizeProfile)) {
+        return res.status(400).json({ message: "sizeProfile must be an object" });
+      }
+      const allowedKeys = ["height", "fitPreference", "topSize", "bottomSize"];
+      for (const key of allowedKeys) {
+        if (key in sizeProfile) {
+          if (typeof sizeProfile[key] !== "string") {
+            return res.status(400).json({ message: `sizeProfile.${key} must be a string` });
+          }
+          updates[`sizeProfile.${key}`] = sizeProfile[key];
+        }
+      }
+    }
+
     if (bio !== undefined) updates.bio = bio;
     if (profilePhoto !== undefined) updates.profilePhoto = profilePhoto;
 
@@ -178,6 +195,7 @@ router.patch("/me", auth, async (req, res) => {
         activeRole: user.activeRole,
         profilePhoto: user.profilePhoto,
         bio: user.bio,
+        sizeProfile: user.sizeProfile,
         isProfileComplete: user.isProfileComplete,
         isRestricted: user.isRestricted,
         badges: user.badges,


### PR DESCRIPTION
This PR adds support for persisting and returning the `sizeProfile` field on the `User` model and `/api/auth/me` endpoints.

Previously, `sizeProfile` was destructured in `PATCH /api/auth/me` but not defined on the `User` Mongoose schema. As a result, it was silently dropped and never persisted or returned from the `/me` endpoints.

### What’s included

- Adds `sizeProfile` to the `User` schema as a nested object with the following sub-fields:
  - `height`
  - `fitPreference`
  - `topSize`
  - `bottomSize`
- Each sub-field:
  - Is of type `String`
  - Defaults to `""`
- The parent `sizeProfile` field defaults to `{}` to ensure the object is always present for both new and existing users.
- Enhances validation in `PATCH /api/auth/me`:
  - Ensures `sizeProfile`, if provided, is a plain object.
  - Ensures any provided sub-fields are strings.
  - Returns `400` for invalid payloads (e.g., non-object `sizeProfile`, non-string sub-fields).
  - Uses dot-notation updates (e.g. `sizeProfile.topSize`) so partial updates do not overwrite other sub-fields.
  - Ignores unexpected keys under `sizeProfile`.
- Updates both:
  - `GET /api/auth/me`
  - `PATCH /api/auth/me`
  
  to include `sizeProfile` in the response.

No changes were made to the API gateway configuration.

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## How Has This Been Tested?

### Manual Verification

1. Started services with:
   ```bash
   docker-compose up
   ```

2. Authenticated and obtained a valid token.

3. **Full update**
   ```http
   PATCH /api/auth/me
   ```
   ```json
   {
     "sizeProfile": {
       "height": "5ft10",
       "fitPreference": "regular",
       "topSize": "M",
       "bottomSize": "32"
     }
   }
   ```
   - ✅ Returns `200`
   - ✅ `sizeProfile` persisted and returned in response

4. **Read back**
   ```http
   GET /api/auth/me
   ```
   - ✅ `sizeProfile` returned with saved values

5. **Partial update**
   ```json
   {
     "sizeProfile": {
       "topSize": "L"
     }
   }
   ```
   - ✅ Returns `200`
   - ✅ Only `topSize` updated
   - ✅ Other sub-fields unchanged

6. **Invalid payload**
   ```json
   {
     "sizeProfile": {
       "height": 123
     }
   }
   ```
   - ✅ Returns `400`
   - ✅ Validation error indicating sub-field must be a string

---