### PR TITLE
Feat/auth include is profile complete in login response

### DIFF
--- a/Backend/services/auth-service/src/routes/authRoutes.js
+++ b/Backend/services/auth-service/src/routes/authRoutes.js
@@ -51,6 +51,7 @@ router.post("/register", async (req, res) => {
         email: user.email,
         role: user.role,
         activeRole: user.activeRole,
+        isProfileComplete: user.isProfileComplete,
       },
     });
   } catch (error) {
@@ -101,6 +102,7 @@ router.post("/login", async (req, res) => {
         email: user.email,
         role: user.role,
         activeRole: user.activeRole,
+        isProfileComplete: user.isProfileComplete,
       },
     });
   } catch (error) {


### PR DESCRIPTION
This pull request updates the authentication responses to include the `isProfileComplete` flag in the returned `user` object. This value is sourced from the database and reflects whether the user has completed their profile.

By exposing `isProfileComplete` directly in the auth responses, the frontend can immediately determine if a user should be redirected to the profile setup flow without requiring an additional API call.

Fixes #107 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Logged in with a user that has a completed profile and verified that `isProfileComplete` is `true` in the `POST /api/auth/login` response.
- [x] Logged in with a user that has an incomplete profile and verified that `isProfileComplete` is `false` in the `POST /api/auth/login` response.
- [x] Registered a new user via `POST /api/auth/register` and verified that the response includes the correct `isProfileComplete` value.
- [x] Confirmed that existing consumers of the auth responses continue to function as expected.